### PR TITLE
Add stdio mcp examples to template

### DIFF
--- a/templates/agent_template.afm.md
+++ b/templates/agent_template.afm.md
@@ -135,7 +135,7 @@ tools:
         args:
           - "-y"
           - "@modelcontextprotocol/server-filesystem"
-          - "/path/to/allowed/directory"
+          - "${env:ALLOWED_DIRECTORY}"
       tool_filter:
         deny:
           - "write_file"

--- a/templates/agent_template.afm.md
+++ b/templates/agent_template.afm.md
@@ -124,6 +124,8 @@ tools:
     # --------------------------------------------------------------------------
     # stdio Transport Examples
     # --------------------------------------------------------------------------
+    # NOTE: stdio transport is currently only supported in the LangChain-based
+    # interpreter for AFM
 
     # MCP Server via npx package
     - name: "filesystem_server"

--- a/templates/agent_template.afm.md
+++ b/templates/agent_template.afm.md
@@ -82,10 +82,14 @@ interfaces:
 # ============================================================================
 tools:
   mcp:
+    # --------------------------------------------------------------------------
+    # HTTP Transport Examples
+    # --------------------------------------------------------------------------
+
     # MCP Server with bearer authentication
     - name: "github_mcp_server"
       transport:
-        type: "http"                     # Only "http" is currently supported
+        type: "http"
         url: "${env:GITHUB_MCP_URL}"
         authentication:
           type: "bearer"
@@ -116,6 +120,39 @@ tools:
       transport:
         type: "http"
         url: "https://public-mcp.example.com"
+
+    # --------------------------------------------------------------------------
+    # stdio Transport Examples
+    # --------------------------------------------------------------------------
+
+    # MCP Server via npx package
+    - name: "filesystem_server"
+      transport:
+        type: "stdio"
+        command: "npx"
+        args:
+          - "-y"
+          - "@modelcontextprotocol/server-filesystem"
+          - "/path/to/allowed/directory"
+      tool_filter:
+        deny:
+          - "write_file"
+          - "edit_file"
+
+    # MCP Server via Python script with environment variables
+    - name: "local_db_tool"
+      transport:
+        type: "stdio"
+        command: "python"
+        args:
+          - "server.py"
+        env:
+          DB_PATH: "./data.db"
+          API_KEY: "${env:LOCAL_DB_API_KEY}"
+      tool_filter:
+        allow:
+          - "query"
+          - "search"
 ---
 
 # Role


### PR DESCRIPTION
## Purpose
Adds stdio MCP examples to `agent_template` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added example configurations and public entries for stdio-based MCP tools, including filesystem and local database server setups.
  * Included tool-filtering examples demonstrating allow/deny access patterns for tool capabilities.

* **Documentation**
  * Enhanced configuration templates with section headers and explanatory notes; removed an obsolete inline comment for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->