### PR TITLE
Return WebSub acknowledgement before running the agent

### DIFF
--- a/ballerina-interpreter/Dependencies.toml
+++ b/ballerina-interpreter/Dependencies.toml
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -382,6 +382,9 @@ version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "time", moduleName = "time"}
+]
 
 [[package]]
 org = "ballerina"
@@ -542,6 +545,7 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "websub"},
 	{org = "ballerina", name = "websubhub"},
 	{org = "ballerinai", name = "observe"},

--- a/ballerina-interpreter/agent.bal
+++ b/ballerina-interpreter/agent.bal
@@ -133,7 +133,7 @@ function getModel(Model? model) returns ai:ModelProvider|error {
 
 const DEFAULT_SESSION_ID = "sessionId";
 
-function runAgent(ai:Agent agent, json payload, map<json>? inputSchema = (), 
+isolated function runAgent(ai:Agent agent, json payload, map<json>? inputSchema = (), 
                   map<json>? outputSchema = (), string sessionId = DEFAULT_SESSION_ID) 
         returns json|InputError|AgentError {
     error? validateJsonSchemaResult = validateJsonSchema(inputSchema, payload);
@@ -209,7 +209,7 @@ function runAgent(ai:Agent agent, json payload, map<json>? inputSchema = (),
     return responseJsonObject.get("value");
 }
 
-function extractJsonFromCodeBlock(string response) returns string {
+isolated function extractJsonFromCodeBlock(string response) returns string {
     // Prioritize ```json block, fall back to generic ```
     int? jsonBlockStart = response.indexOf("```json");
     int? contentStart = jsonBlockStart is int ? jsonBlockStart + 7 : ();

--- a/ballerina-interpreter/interface_web_chat.bal
+++ b/ballerina-interpreter/interface_web_chat.bal
@@ -31,20 +31,20 @@ function attachChatService(http:Listener httpListener, ai:Agent agent,
     return httpListener.attach(httpService, httpExposure.path);
 }
 
-service class ChatHttpService {
+isolated service class ChatHttpService {
     *http:Service;
 
     private final readonly & map<json> inputSchema;
     private final readonly & map<json> outputSchema;
     private final ai:Agent agent;
 
-    function init(ai:Agent agent, WebChatInterface webChatInterface) returns error? {
+    isolated function init(ai:Agent agent, WebChatInterface webChatInterface) returns error? {
         self.inputSchema = webChatInterface.signature.input.cloneReadOnly();
         self.outputSchema = webChatInterface.signature.output.cloneReadOnly();
         self.agent = agent;
     }
 
-    resource function post .(@http:Payload json payload) returns json|http:BadRequest|http:InternalServerError {
+    isolated resource function post .(@http:Payload json payload) returns json|http:BadRequest|http:InternalServerError {
         json|InputError|AgentError runAgentResult = runAgent(self.agent, payload, self.inputSchema, self.outputSchema);
         if runAgentResult is json {
             return runAgentResult;
@@ -57,16 +57,16 @@ service class ChatHttpService {
     }
 }
 
-service class StringChatHttpService {
+isolated service class StringChatHttpService {
     *http:Service;
 
     private final ai:Agent agent;
 
-    function init(ai:Agent agent) returns error? {
+    isolated function init(ai:Agent agent) returns error? {
         self.agent = agent;
     }
 
-    resource function post .(@http:Payload string payload, 
+    isolated resource function post .(@http:Payload string payload, 
                              @http:Header {name: "X-Session-Id"} string sessionId = DEFAULT_SESSION_ID) 
                                 returns string|http:InternalServerError {
         string|error runAgentResult = runAgent(self.agent, payload, sessionId = sessionId).ensureType();

--- a/ballerina-interpreter/interface_webhook.bal
+++ b/ballerina-interpreter/interface_webhook.bal
@@ -53,7 +53,7 @@ function attachWebhookService(websub:Listener websubListener, ai:Agent agent, We
             callback: subscription.callback
         }
         isolated service object {
-            remote function onEventNotification(readonly & websub:ContentDistributionMessage msg)
+            isolated remote function onEventNotification(readonly & websub:ContentDistributionMessage msg)
                     returns websub:Acknowledgement|error {
                 _ = start runAgentOnWebSubEventNotification(compiledPrompt, msg, agent);
                 return websub:ACKNOWLEDGEMENT;
@@ -63,7 +63,7 @@ function attachWebhookService(websub:Listener websubListener, ai:Agent agent, We
     return websubListener.attach(webhookService, httpExposure.path);
 }
 
-function runAgentOnWebSubEventNotification(readonly & CompiledTemplate? compiledPrompt,
+isolated function runAgentOnWebSubEventNotification(readonly & CompiledTemplate? compiledPrompt,
                    readonly & websub:ContentDistributionMessage msg,
                    ai:Agent agent) {
     json payload = msg.content.toJson();
@@ -152,7 +152,8 @@ function compileTemplate(string template) returns CompiledTemplate|error {
     return {segments: segments.cloneReadOnly()};
 }
 
-function evaluateTemplate(CompiledTemplate compiled, json payload, map<string|string[]>? headers) returns string|error {
+isolated function evaluateTemplate(
+        CompiledTemplate compiled, json payload, map<string|string[]>? headers) returns string|error {
     string[] parts = [];
 
     foreach TemplateSegment segment in compiled.segments {
@@ -197,7 +198,7 @@ function evaluateTemplate(CompiledTemplate compiled, json payload, map<string|st
     return string:'join("", ...parts);
 }
 
-function handlePayloadVariable(json payload, string[] parts, PayloadVariable segment) {
+isolated function handlePayloadVariable(json payload, string[] parts, PayloadVariable segment) {
     if segment.path == "" {
         // ${http:payload} - return entire payload
         parts.push(payload.toJsonString());
@@ -218,7 +219,7 @@ function handlePayloadVariable(json payload, string[] parts, PayloadVariable seg
 
 // Access a JSON field using dot notation or bracket notation
 // Supports: field.nested, field['key'], field[0], etc.
-function accessJsonField(json payload, string path) returns json|error {
+isolated function accessJsonField(json payload, string path) returns json|error {
     // Handle bracket notation like ['field.with.dots'] or [0]
     if path.startsWith("[") {
         return handleBracketNotation(payload, path);
@@ -228,7 +229,7 @@ function accessJsonField(json payload, string path) returns json|error {
     return handleDotNotation(payload, path);
 }
 
-function handleBracketNotation(json payload, string path) returns json|error {
+isolated function handleBracketNotation(json payload, string path) returns json|error {
     int? closeBracket = path.indexOf("]");
     if closeBracket is () {
         return error(string `Invalid bracket notation in path: ${path}`);
@@ -261,7 +262,7 @@ function handleBracketNotation(json payload, string path) returns json|error {
     return accessJsonField(nextValue, remainingPath);
 }
 
-function handleQuotedKey(json payload, string bracketContent) returns json|error {
+isolated function handleQuotedKey(json payload, string bracketContent) returns json|error {
     string key = bracketContent.substring(1, bracketContent.length() - 1);
 
     if !(payload is map<json>) {
@@ -276,7 +277,7 @@ function handleQuotedKey(json payload, string bracketContent) returns json|error
     return value;
 }
 
-function handleArrayIndex(json payload, string bracketContent) returns json|error {
+isolated function handleArrayIndex(json payload, string bracketContent) returns json|error {
     int|error index = int:fromString(bracketContent);
     if index is error {
         return error(string `Invalid array index: ${bracketContent}`);
@@ -293,7 +294,7 @@ function handleArrayIndex(json payload, string bracketContent) returns json|erro
     return payload[index];
 }
 
-function handleDotNotation(json payload, string path) returns json|error {
+isolated function handleDotNotation(json payload, string path) returns json|error {
     string[] parts = regexp:split(re `\.`, path);
     json current = payload;
 
@@ -324,7 +325,7 @@ function handleDotNotation(json payload, string path) returns json|error {
     return current;
 }
 
-function handleMixedNotation(json current, string part) returns json|error {
+isolated function handleMixedNotation(json current, string part) returns json|error {
     int? bracketPos = part.indexOf("[");
     if bracketPos is () {
         return error(string `Invalid mixed notation in part: ${part}`);

--- a/ballerina-interpreter/interface_webhook.bal
+++ b/ballerina-interpreter/interface_webhook.bal
@@ -55,11 +55,7 @@ function attachWebhookService(websub:Listener websubListener, ai:Agent agent, We
         isolated service object {
             remote function onEventNotification(readonly & websub:ContentDistributionMessage msg)
                     returns websub:Acknowledgement|error {
-                json payload = msg.content.toJson();
-
-                json result = check getResult(compiledPrompt, payload, msg, agent);
-
-                log:printInfo("Webhook payload handled: " + result.toJsonString());
+                _ = start runAgentOnWebSubEventNotification(compiledPrompt, msg, agent);
                 return websub:ACKNOWLEDGEMENT;
             }
         };
@@ -67,14 +63,24 @@ function attachWebhookService(websub:Listener websubListener, ai:Agent agent, We
     return websubListener.attach(webhookService, httpExposure.path);
 }
 
-function getResult(readonly & CompiledTemplate? compiledPrompt,
-                   json payload,
+function runAgentOnWebSubEventNotification(readonly & CompiledTemplate? compiledPrompt,
                    readonly & websub:ContentDistributionMessage msg,
-                   ai:Agent agent) returns json|error {
-    json agentInput = compiledPrompt is CompiledTemplate ?
-        check evaluateTemplate(compiledPrompt, payload, msg.headers) :
+                   ai:Agent agent) {
+    json payload = msg.content.toJson();
+    json|error agentInput = compiledPrompt is CompiledTemplate ?
+        evaluateTemplate(compiledPrompt, payload, msg.headers) :
         payload;
-    return runAgent(agent, agentInput);
+    if agentInput is error {
+        log:printError("Error evaluating prompt template", agentInput);
+        return;
+    }
+
+    json|error result = runAgent(agent, agentInput);
+    if result is error {
+        log:printError("Error processing webhook payload", result);
+        return;
+    }
+    log:printDebug("Webhook event handled successfully");
 }
 
 function compileTemplate(string template) returns CompiledTemplate|error {

--- a/ballerina-interpreter/tests/interface_webhook_test.bal
+++ b/ballerina-interpreter/tests/interface_webhook_test.bal
@@ -14,11 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/file;
 import ballerina/http;
+import ballerina/io;
 import ballerina/lang.runtime;
 import ballerina/log;
 import ballerina/os;
 import ballerina/test;
+import ballerina/time;
 import ballerina/websubhub;
 
 // In-memory store for subscriptions
@@ -254,4 +257,114 @@ function testWebhookEndToEnd() returns error? {
 
     error? stopResult = hubListener.gracefulStop();
     test:assertTrue(stopResult is (), "Hub listener should stop gracefully");
+    check os:unsetEnv("WH_HOST");
+}
+
+// Delay used by the slow mock LLM to simulate a long-running agent invocation.
+const decimal SLOW_MOCK_LLM_DELAY = 5;
+
+// Polls the hub's subscription map until the expected subscription appears,
+// to avoid timing-sensitive fixed sleeps while waiting for an AFM agent to
+// complete its WebSub subscription.
+function waitForSubscription(string topicUrl, decimal timeoutSeconds = 15) returns error? {
+    decimal deadline = time:monotonicNow() + timeoutSeconds;
+    while time:monotonicNow() < deadline {
+        if subscriptions.hasKey(topicUrl) {
+            return;
+        }
+        runtime:sleep(0.1);
+    }
+    return error(string `Timed out after ${timeoutSeconds}s waiting for subscription to ${topicUrl}`);
+}
+
+// Number of times the slow mock LLM endpoint has been invoked. Used by the
+// test to assert that the background agent execution actually reached the LLM.
+isolated int slowMockCallCount = 0;
+
+// Mock HTTP service for LLM that sleeps before responding, used to verify
+// that the webhook subscriber acknowledges before the agent completes.
+service /slow\-llm/v1\.0 on new http:Listener(29194) {
+
+    resource function post webhook/chat/completions(@http:Payload json _payload) returns json {
+        lock {
+            slowMockCallCount += 1;
+        }
+        runtime:sleep(SLOW_MOCK_LLM_DELAY);
+        return {
+            "id": "chatcmpl-slow-mock",
+            "object": "chat.completion",
+            "created": 1234567890,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Slowly processed."
+                    },
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30
+            }
+        };
+    }
+}
+
+// Verifies that the WebSub subscriber returns an acknowledgement before the
+// agent execution completes, as required by the WebSub spec.
+// Uses a slow mock LLM so the agent run takes ~SLOW_MOCK_LLM_DELAY seconds;
+// the publisher should receive a success response well before that delay elapses.
+@test:Config
+function testWebhookAcknowledgesBeforeAgentCompletes() returns error? {
+    lock {
+        slowMockCallCount = 0;
+    }
+    check os:setEnv("WH_SLOW_HOST", "http://localhost:28086");
+
+    // Start an independent WebSub hub on a dedicated port to avoid
+    // interfering with the other webhook test's hub.
+    websubhub:Listener hubListener = check new (29195);
+    check hubListener.attach(hubService, "/websub/hub");
+    check hubListener.'start();
+
+    // Call runAgentFromAFM directly so the port doesn't collide with the other
+    // test's main() which uses the module-level configurable port (8085).
+    string afmPath = "tests/sample_webhook_agent_slow.afm.md";
+    string afmContent = check io:fileReadString(afmPath);
+    AFMRecord afm = check parseAfm(afmContent);
+    string afmFileDir = check file:parentPath(check file:getAbsolutePath(afmPath));
+    future<error?> _ = start runAgentFromAFM(afm, 28086, afmFileDir);
+
+    string topicUrl = "http://localhost:29195/events/slow-orders";
+    check waitForSubscription(topicUrl);
+
+    websubhub:PublisherClient publisher = check new ("http://localhost:29195/websub/hub");
+
+    decimal before = time:monotonicNow();
+    _ = check publisher->publishUpdate(topicUrl, <map<json>> {event: "slow.test", orderId: "1"});
+    decimal elapsed = time:monotonicNow() - before;
+
+    // The subscriber must acknowledge the content distribution request before
+    // the agent completes. The slow mock LLM sleeps for SLOW_MOCK_LLM_DELAY
+    // seconds, so if acknowledgement is synchronous the publish call will take
+    // at least that long.
+    test:assertTrue(elapsed < 2d,
+        string `publishUpdate returned in ${elapsed}s; expected fast ack ` +
+        string `(< 2s) while agent runs for ~${SLOW_MOCK_LLM_DELAY}s in the background`);
+
+    // Allow the background agent run to complete before the hub listener shuts
+    // down so we don't leave dangling HTTP work.
+    runtime:sleep(SLOW_MOCK_LLM_DELAY + 1d);
+
+    lock {
+        test:assertEquals(slowMockCallCount, 1,
+            "Slow mock LLM should have been invoked exactly once by the background agent run");
+    }
+    error? stopResult = hubListener.gracefulStop();
+    test:assertTrue(stopResult is (), "Hub listener should stop gracefully");
+    check os:unsetEnv("WH_SLOW_HOST");
 }

--- a/ballerina-interpreter/tests/sample_webhook_agent_slow.afm.md
+++ b/ballerina-interpreter/tests/sample_webhook_agent_slow.afm.md
@@ -1,0 +1,28 @@
+---
+spec_version: '0.3.0'
+name: "WebhookSlowTestAgent"
+description: "A test agent for verifying the webhook fast-ack behavior with a slow LLM."
+author: "Copilot"
+version: "0.1.0"
+interfaces:
+  - type: webhook
+    prompt: "Process: ${http:payload}"
+    subscription:
+      protocol: "websub"
+      hub: "http://localhost:29195/websub/hub"
+      topic: "http://localhost:29195/events/slow-orders"
+      callback: "${env:WH_SLOW_HOST}/webhook"
+max_iterations: 1
+model:
+  provider: "wso2"
+  url: "http://localhost:29194/slow-llm/v1.0/webhook"
+  authentication:
+    type: "bearer"
+    token: "mock-token"
+---
+
+# Role
+You are a slow order processing assistant used to verify fast acknowledgement behavior.
+
+# Instructions
+- Process incoming order events.


### PR DESCRIPTION
## Purpose
$title.

Addresses https://github.com/wso2/reference-implementations-afm/issues/17 for the Ballerina interpreter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhooks now acknowledge events immediately and process agents asynchronously for faster responses.

* **Tests**
  * Added end-to-end test verifying webhook acknowledges before agent processing completes.
  * Added a slow-agent test specification to simulate delayed model responses.

* **Chores**
  * Updated dependency metadata (minor version bump and module declarations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->