### PR TITLE
Fix trivy action tag

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -109,7 +109,7 @@ jobs:
             index:org.opencontainers.image.licenses=Apache-2.0
 
       - name: Scan full Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.docker-tags.outputs.BASE_IMAGE }}:v${{ inputs.version }}
           format: "sarif"
@@ -127,7 +127,7 @@ jobs:
 
       - name: Scan slim Docker image for vulnerabilities
         if: ${{ always() && inputs.build_slim }}
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.docker-tags.outputs.BASE_IMAGE }}:v${{ inputs.version }}-slim
           format: "sarif"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -109,7 +109,7 @@ jobs:
             index:org.opencontainers.image.licenses=Apache-2.0
 
       - name: Scan full Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.docker-tags.outputs.BASE_IMAGE }}:v${{ inputs.version }}
           format: "sarif"
@@ -127,7 +127,7 @@ jobs:
 
       - name: Scan slim Docker image for vulnerabilities
         if: ${{ always() && inputs.build_slim }}
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.docker-tags.outputs.BASE_IMAGE }}:v${{ inputs.version }}-slim
           format: "sarif"


### PR DESCRIPTION
## Purpose
`aquasecurity/trivy-action` has updated their version tags after a supply chain attack. More information regarding the change can be found in the release notes here: https://github.com/aquasecurity/trivy/discussions/10425

This PR updates that action to latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a newer version of the CI vulnerability scanner used for Docker image scans to ensure up-to-date scanning in release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->