### PR TITLE
Fix: ignore blank lines in parser (Resolves #32)

### DIFF
--- a/ballerina-interpreter/parser.bal
+++ b/ballerina-interpreter/parser.bal
@@ -20,9 +20,18 @@ import ballerina/os;
 function parseAfm(string content) returns AFMRecord|error {
     string resolvedContent = check resolveVariables(content);
 
+    string[] resolvedLines = splitLines(resolvedContent);
+    int firstNonBlank = 0;
+    while firstNonBlank < resolvedLines.length() && resolvedLines[firstNonBlank].trim() == "" {
+        firstNonBlank += 1;
+    }
+    if firstNonBlank > 0 {
+        resolvedContent = string:'join("\n", ...resolvedLines.slice(firstNonBlank));
+        resolvedLines = splitLines(resolvedContent);
+    }
+
     AgentMetadata? metadata = ();
     string body;
-    string[] resolvedLines = splitLines(resolvedContent);
     if resolvedLines.length() > 0 && resolvedLines[0].trim() == FRONTMATTER_DELIMITER {
         map<json> frontmatterMap;
         [frontmatterMap, body] = check extractFrontMatter(resolvedContent);

--- a/ballerina-interpreter/tests/agent_test.bal
+++ b/ballerina-interpreter/tests/agent_test.bal
@@ -339,6 +339,29 @@ function testGetModelUnsupportedProvider() returns error? {
     test:assertTrue((<error>result).message().includes("not yet supported"));
 }
 
+@test:Config
+function testParseAfmIgnoresLeadingBlankLines() returns error? {
+    string content = "\n\n---\n" +
+        "model:\n" +
+        "  provider: \"ollama\"\n" +
+        "  name: \"llama3\"\n" +
+        "---\n\n" +
+        "# Role\n" +
+        "You are a helpful assistant.\n\n" +
+        "# Instructions\n" +
+        "Be concise.\n";
+
+    AFMRecord afm = check parseAfm(content);
+
+    AgentMetadata? metadata = afm.metadata;
+    test:assertTrue(metadata is AgentMetadata);
+    Model? model = (<AgentMetadata>metadata).model;
+    test:assertTrue(model is Model);
+    test:assertEquals((<Model>model).provider, "ollama");
+    test:assertEquals((<Model>model).name, "llama3");
+    test:assertEquals(afm.role, "You are a helpful assistant.");
+}
+
 function extractJsonFromCodeBlockDataProvider() returns [string, string, string][] {
     return [
         ["json marker", "Here is the result:\n```json\n{\"name\": \"Alice\"}\n```\nDone.", "{\"name\": \"Alice\"}"],

--- a/python-interpreter/packages/afm-core/src/afm/parser.py
+++ b/python-interpreter/packages/afm-core/src/afm/parser.py
@@ -36,11 +36,15 @@ def extract_raw_frontmatter(content: str) -> tuple[dict | None, str]:
     """
     lines = content.splitlines()
 
-    if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+
+    if start >= len(lines) or lines[start].strip() != FRONTMATTER_DELIMITER:
         return None, content
 
     end_index = None
-    for i in range(1, len(lines)):
+    for i in range(start + 1, len(lines)):
         if lines[i].strip() == FRONTMATTER_DELIMITER:
             end_index = i
             break
@@ -48,7 +52,7 @@ def extract_raw_frontmatter(content: str) -> tuple[dict | None, str]:
     if end_index is None:
         raise ValueError("Unclosed frontmatter - missing closing '---'")
 
-    yaml_content = "\n".join(lines[1:end_index])
+    yaml_content = "\n".join(lines[start + 1 : end_index])
     body = "\n".join(lines[end_index + 1 :])
 
     if not yaml_content.strip():

--- a/python-interpreter/packages/afm-core/tests/test_parser.py
+++ b/python-interpreter/packages/afm-core/tests/test_parser.py
@@ -141,6 +141,31 @@ class TestParseAfm:
         assert result.role == "This is the role without frontmatter."
         assert result.instructions == "These are instructions without frontmatter."
 
+    def test_parse_frontmatter_with_leading_blank_lines(self) -> None:
+        content = """
+
+---
+spec_version: "0.3.0"
+model:
+  provider: "ollama"
+  name: "llama3"
+---
+
+# Role
+The role.
+
+# Instructions
+The instructions.
+"""
+        result = parse_afm(content)
+
+        assert result.metadata.spec_version == "0.3.0"
+        assert result.metadata.model is not None
+        assert result.metadata.model.provider == "ollama"
+        assert result.metadata.model.name == "llama3"
+        assert result.role == "The role."
+        assert result.instructions == "The instructions."
+
     def test_parse_unclosed_frontmatter(self) -> None:
         content = """---
 spec_version: "0.3.0"


### PR DESCRIPTION
## Purpose

When an `.afm.md` file has one or more blank lines before the opening `---`, both interpreters ignore the whole frontmatter. Because of this, the `model` block is dropped and the interpreter silently falls back to its default provider (OpenAI in Python, WSO2 in Ballerina), which then fails with a confusing, unrelated error (e.g. "No API key found"). The provider the user actually wrote is never used.

Resolves #32

## Goals

* Make both interpreters ignore any leading blank lines and read the frontmatter correctly.
* Make sure a file that declares a provider (e.g. `ollama`) actually uses that provider, even if it starts with a blank line.
* Keep the change small and not touch the spec.

## Approach

> The root cause is that both parsers only look at the **first line** for the `---` delimiter, so a blank first line makes them think there is no frontmatter.

* **Python** (`packages/afm-core/src/afm/parser.py`): in `extract_raw_frontmatter`, skip leading blank lines before checking for the opening `---`. This function is shared by the AFM parser and the skills parser, so both are fixed.
* **Ballerina** (`ballerina-interpreter/parser.bal`): in `parseAfm`, drop leading blank lines from the content before detecting the frontmatter.

Both changes are a no-op for normal files (where `---` is already the first line), so existing behaviour is unchanged. A regression test was added in each interpreter that parses a file starting with blank lines and confirms the `model` block is read correctly.

No UI changes.

## User stories

* As an AFM author, when my file accidentally starts with a blank line before `---`, the interpreter still reads my frontmatter and uses the model/provider I declared, instead of silently using a default one.

## Release note

Fixed AFM files that begin with blank lines before the `---` frontmatter being parsed as having no frontmatter, which caused the declared model provider to be ignored. Leading blank lines are now skipped in both the Python and Ballerina interpreters.